### PR TITLE
allow using elm-community/list-extra up to 3.x.x

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "1.0.0 <= v < 2.0.0",
         "elm-community/json-extra": "1.0.0 <= v < 2.0.0",
-        "elm-community/list-extra": "2.0.1 <= v < 3.0.0",
+        "elm-community/list-extra": "2.0.1 <= v < 4.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0"
     },
     "elm-version": "0.17.0 <= v < 0.18.0"


### PR DESCRIPTION
Thanks for elm-jsonapi, using JSON API with Elm sounds really promising.

I was trying to use it in my project which already uses list-extra v3.0.0. It conflicted with elm-jsonapi dependency limiting the version to v2.x.x. So I've just updated

I'm using Elm 0.17.1 and the latest version of a few packages which are conflicting with elm-jsonapi v1.0.0 (i.e.: elm-community/list-extra v2.0.1 vs v3.0.0).

So I've updated dependencies definition accordingly and ran successfully the tests, as well as manually testing in my own app of course.