### PR TITLE
upgrade dependency to list-extra

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -18,7 +18,7 @@
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
         "danyx23/elm-uuid": "2.0.2 <= v < 3.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
+        "elm-community/list-extra": "5.0.0 <= v < 6.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -15,7 +15,7 @@
         "danyx23/elm-uuid": "2.0.2 <= v < 3.0.0",
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
-        "elm-community/list-extra": "4.0.0 <= v < 5.0.0",
+        "elm-community/list-extra": "5.0.0 <= v < 6.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },


### PR DESCRIPTION
This allows installation of elm-jsonapi along with other packages, for example https://github.com/apuchenkin/elm-nested-router

The only function used from `List.Extra` seems to be `find` which appears not to have been changed since 2 years.