### PR TITLE
Allow null resource object and null resource object identifier

### DIFF
--- a/src/JsonApi/Decode.elm
+++ b/src/JsonApi/Decode.elm
@@ -81,7 +81,7 @@ data : Decoder (OneOrMany RawResource)
 data =
     oneOf
         [ Json.Decode.map Many (list resource)
-        , Json.Decode.map One resource
+        , Json.Decode.map One (nullable resource)
         ]
 
 
@@ -137,7 +137,7 @@ relationshipData : Decoder (OneOrMany ResourceIdentifier)
 relationshipData =
     oneOf
         [ Json.Decode.map Many (list resourceIdentifier)
-        , Json.Decode.map One resourceIdentifier
+        , Json.Decode.map One (nullable resourceIdentifier)
         ]
 
 

--- a/src/JsonApi/Documents.elm
+++ b/src/JsonApi/Documents.elm
@@ -24,9 +24,9 @@ import List.Extra
     This function assumes a singular primary resource and will return an Err
     if the document contains a collection of primary resources.
 -}
-primaryResource : Document -> Result String Resource
+primaryResource : Document -> Result String (Maybe Resource)
 primaryResource (Document doc) =
-    Result.map (hydratePrimaryResource doc.included) (extractOne doc.data)
+    Result.map (Maybe.map (hydratePrimaryResource doc.included)) (extractOne doc.data)
 
 
 {-| Retrieve a collection of primary resources from a decoded Document.

--- a/src/JsonApi/Encode.elm
+++ b/src/JsonApi/Encode.elm
@@ -57,7 +57,7 @@ relationship rel =
         data =
             case (OneOrMany.map resourceIdentifier rel.data) of
                 One value ->
-                    value
+                    Maybe.withDefault Encode.null value
 
                 Many values ->
                     Encode.list values

--- a/src/JsonApi/OneOrMany.elm
+++ b/src/JsonApi/OneOrMany.elm
@@ -2,7 +2,7 @@ module JsonApi.OneOrMany exposing (..)
 
 
 type OneOrMany a
-    = One a
+    = One (Maybe a)
     | Many (List a)
 
 
@@ -10,13 +10,13 @@ map : (a -> b) -> OneOrMany a -> OneOrMany b
 map fn oneOrMany =
     case oneOrMany of
         One x ->
-            One (fn x)
+            One (Maybe.map fn x)
 
         Many xs ->
             Many (List.map fn xs)
 
 
-extractOne : OneOrMany a -> Result String a
+extractOne : OneOrMany a -> Result String (Maybe a)
 extractOne oneOrMany =
     case oneOrMany of
         One x ->

--- a/tests/Test/Examples.elm
+++ b/tests/Test/Examples.elm
@@ -30,6 +30,13 @@ validPayload =
             },
             "data": { "type": "people", "id": "9" }
           },
+          "category": {
+            "links": {
+              "self": "http://example.com/articles/1/relationships/category",
+              "related": "http://example.com/articles/1/category"
+            },
+            "data": null
+          },
           "comments": {
             "links": {
               "self": "http://example.com/articles/1/relationships/comments",

--- a/tests/Test/JsonApi/Decode.elm
+++ b/tests/Test/JsonApi/Decode.elm
@@ -57,8 +57,9 @@ decodesPayloadWithResourceIdentifiers =
             decodeString JsonApi.Decode.document payloadWithResourceIdentifiers
                 |> Result.andThen JsonApi.Documents.primaryResource
                 |> Result.toMaybe
-                |> Maybe.andThen JsonApi.Resources.meta
+                |> Maybe.andThen (Maybe.map JsonApi.Resources.meta)
                 |> Result.fromMaybe "Meta not found"
+                |> Result.andThen (Result.fromMaybe "Meta is null")
                 |> Result.andThen (Json.Decode.decodeValue Json.Decode.string)
     in
         (\_ -> Expect.equal resourceIdentifierMeta (Ok "this is the second article"))


### PR DESCRIPTION
The spec allows these both to be null:

* http://jsonapi.org/format/#document-top-level
* http://jsonapi.org/format/#document-resource-object-linkage